### PR TITLE
Workflow versioning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # Local development only
       - "4200:4200"
     networks:
-      - traefik
+      - traefik-prefect
     env_file: .env
 
   reverse-proxy:
@@ -43,11 +43,11 @@ services:
       - host.docker.internal:127.0.0.1
     ports:
       # The HTTP port
-      - "80:80"
+      - "81:81"
       # The HTTPS port
-      - "443:443"
+      - "444:444"
       # The Web UI (enabled by --api.insecure=true)
-      - "8089:8080"
+      - "8090:8081"
     environment:
       - "traefikhost"
       - "hostname"
@@ -60,9 +60,9 @@ services:
       # - ./traefik/traefik.toml:/traefik.toml
       - ./traefik/rules-infra.toml:/etc/traefik/conf.d/rules.toml
     networks:
-      - traefik
+      - traefik-prefect
       - default
 
 networks:
-  traefik:
+  traefik-prefect:
     external: true

--- a/prefect_docker/scripts/flows/cbs_ingestion.py
+++ b/prefect_docker/scripts/flows/cbs_ingestion.py
@@ -3,7 +3,7 @@ import os
 from prefect import flow
 from prefect.orion.schemas.states import Completed, Failed
 from tasks.base_tasks import xml2json, dataverse_mapper, \
-    dataverse_import, update_publication_date
+    dataverse_import, update_publication_date, add_workflow_versioning_url
 
 CBS_MAPPING_FILE_PATH = os.getenv('CBS_MAPPING_FILE_PATH')
 CBS_TEMPLATE_FILE_PATH = os.getenv('CBS_TEMPLATE_FILE_PATH')
@@ -11,7 +11,7 @@ CBS_DATAVERSE_ALIAS = os.getenv('CBS_DATAVERSE_ALIAS')
 
 
 @flow
-def cbs_metadata_ingestion(file_path):
+def cbs_metadata_ingestion(file_path, version):
     json_metadata = xml2json(file_path)
     if not json_metadata:
         return Failed(message='Unable to transform from xml to json.')
@@ -20,6 +20,8 @@ def cbs_metadata_ingestion(file_path):
                                        CBS_TEMPLATE_FILE_PATH, False)
     if not mapped_metadata:
         return Failed(message='Unable to map metadata.')
+
+    mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
 
     import_response = dataverse_import(mapped_metadata, CBS_DATAVERSE_ALIAS)
     if not import_response:

--- a/prefect_docker/scripts/flows/cbs_ingestion.py
+++ b/prefect_docker/scripts/flows/cbs_ingestion.py
@@ -22,6 +22,8 @@ def cbs_metadata_ingestion(file_path, version):
         return Failed(message='Unable to map metadata.')
 
     mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
+    if not mapped_metadata:
+        return Failed(message='Unable to store workflow version.')
 
     import_response = dataverse_import(mapped_metadata, CBS_DATAVERSE_ALIAS)
     if not import_response:

--- a/prefect_docker/scripts/flows/dataverse_nl_ingestion.py
+++ b/prefect_docker/scripts/flows/dataverse_nl_ingestion.py
@@ -6,7 +6,8 @@ from prefect.orion.schemas.states import Failed, Completed
 
 from tasks.base_tasks import xml2json, get_doi_from_header, \
     dataverse_metadata_fetcher, \
-    dataverse_import, add_contact_email, update_publication_date
+    dataverse_import, add_contact_email, update_publication_date, \
+    add_workflow_versioning_url
 
 DATAVERSE_NL_DATAVERSE_ALIAS = os.getenv('DATAVERSE_NL_DATAVERSE_ALIAS')
 DATAVERSE_NL_SOURCE_DATAVERSE_URL = os.getenv(
@@ -14,7 +15,7 @@ DATAVERSE_NL_SOURCE_DATAVERSE_URL = os.getenv(
 
 
 @flow
-def dataverse_nl_metadata_ingestion(file_path):
+def dataverse_nl_metadata_ingestion(file_path, version):
     metadata_format = "dataverse_json"
     json_metadata = xml2json(file_path)
     if not json_metadata:
@@ -41,6 +42,8 @@ def dataverse_nl_metadata_ingestion(file_path):
         dataverse_json["datasetVersion"]['metadataBlocks'])
     dataverse_json['datasetVersion'] = {}
     dataverse_json['datasetVersion']['metadataBlocks'] = metadata_blocks
+
+    dataverse_json = add_workflow_versioning_url(dataverse_json, version)
 
     import_response = dataverse_import(dataverse_json,
                                        DATAVERSE_NL_DATAVERSE_ALIAS, doi)

--- a/prefect_docker/scripts/flows/dataverse_nl_ingestion.py
+++ b/prefect_docker/scripts/flows/dataverse_nl_ingestion.py
@@ -44,6 +44,8 @@ def dataverse_nl_metadata_ingestion(file_path, version):
     dataverse_json['datasetVersion']['metadataBlocks'] = metadata_blocks
 
     dataverse_json = add_workflow_versioning_url(dataverse_json, version)
+    if not dataverse_json:
+        return Failed(message='Unable to store workflow version.')
 
     import_response = dataverse_import(dataverse_json,
                                        DATAVERSE_NL_DATAVERSE_ALIAS, doi)

--- a/prefect_docker/scripts/flows/easy_ingestion.py
+++ b/prefect_docker/scripts/flows/easy_ingestion.py
@@ -5,7 +5,7 @@ from prefect.orion.schemas.states import Completed, Failed
 
 from tasks.base_tasks import xml2json, dataverse_mapper, \
     dataverse_import, update_publication_date, get_license, \
-    get_doi_from_dv_json
+    get_doi_from_dv_json, add_workflow_versioning_url
 
 EASY_MAPPING_FILE_PATH = os.getenv('EASY_MAPPING_FILE_PATH')
 EASY_TEMPLATE_FILE_PATH = os.getenv('EASY_TEMPLATE_FILE_PATH')
@@ -13,7 +13,7 @@ EASY_DATAVERSE_ALIAS = os.getenv('EASY_DATAVERSE_ALIAS')
 
 
 @flow
-def easy_metadata_ingestion(file_path):
+def easy_metadata_ingestion(file_path, version):
     json_metadata = xml2json(file_path)
     if not json_metadata:
         return Failed(message='Unable to transform from xml to json')
@@ -29,6 +29,8 @@ def easy_metadata_ingestion(file_path):
 
     dataset_license = get_license(json_metadata)
     mapped_metadata["datasetVersion"]["license"] = dataset_license
+
+    mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
 
     import_response = dataverse_import(mapped_metadata, EASY_DATAVERSE_ALIAS,
                                        doi)

--- a/prefect_docker/scripts/flows/easy_ingestion.py
+++ b/prefect_docker/scripts/flows/easy_ingestion.py
@@ -31,6 +31,8 @@ def easy_metadata_ingestion(file_path, version):
     mapped_metadata["datasetVersion"]["license"] = dataset_license
 
     mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
+    if not mapped_metadata:
+        return Failed(message='Unable to store workflow version.')
 
     import_response = dataverse_import(mapped_metadata, EASY_DATAVERSE_ALIAS,
                                        doi)

--- a/prefect_docker/scripts/flows/liss_ingestion.py
+++ b/prefect_docker/scripts/flows/liss_ingestion.py
@@ -4,7 +4,8 @@ from prefect import flow
 from prefect.orion.schemas.states import Completed, Failed
 
 from tasks.base_tasks import xml2json, dataverse_mapper, \
-    dataverse_import, update_publication_date, get_doi_from_dv_json
+    dataverse_import, update_publication_date, get_doi_from_dv_json, \
+    add_workflow_versioning_url
 from utils import is_lower_level_liss_study
 
 LISS_MAPPING_FILE_PATH = os.getenv('LISS_MAPPING_FILE_PATH')
@@ -13,7 +14,7 @@ LISS_DATAVERSE_ALIAS = os.getenv('LISS_DATAVERSE_ALIAS')
 
 
 @flow
-def liss_metadata_ingestion(file_path):
+def liss_metadata_ingestion(file_path, version):
     json_metadata = xml2json(file_path)
     if not json_metadata:
         return Failed(message='Unable to transform from xml to json')
@@ -29,6 +30,8 @@ def liss_metadata_ingestion(file_path):
     doi = get_doi_from_dv_json(mapped_metadata)
     if not doi:
         return Failed(message='Missing DOI in mapped metadata.')
+
+    # mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
 
     import_response = dataverse_import(mapped_metadata, LISS_DATAVERSE_ALIAS,
                                        doi)

--- a/prefect_docker/scripts/flows/liss_ingestion.py
+++ b/prefect_docker/scripts/flows/liss_ingestion.py
@@ -32,6 +32,8 @@ def liss_metadata_ingestion(file_path, version):
         return Failed(message='Missing DOI in mapped metadata.')
 
     mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
+    if not mapped_metadata:
+        return Failed(message='Unable to store workflow version.')
 
     import_response = dataverse_import(mapped_metadata, LISS_DATAVERSE_ALIAS,
                                        doi)

--- a/prefect_docker/scripts/flows/liss_ingestion.py
+++ b/prefect_docker/scripts/flows/liss_ingestion.py
@@ -31,7 +31,7 @@ def liss_metadata_ingestion(file_path, version):
     if not doi:
         return Failed(message='Missing DOI in mapped metadata.')
 
-    # mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
+    mapped_metadata = add_workflow_versioning_url(mapped_metadata, version)
 
     import_response = dataverse_import(mapped_metadata, LISS_DATAVERSE_ALIAS,
                                        doi)

--- a/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
+++ b/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
@@ -1,6 +1,6 @@
 import os
 from prefect import flow
-from tasks.versioning_tasks import get_service_version
+from tasks.versioning_tasks import get_service_version, store_workflow_version
 
 VERSION = os.getenv('VERSION')
 
@@ -81,4 +81,6 @@ def create_ingestion_workflow_versioning(transformer=None, mapper=None,
         )
         version_dict[updater_name] = updater
 
-    return version_dict
+    version = store_workflow_version(version_dict)
+
+    return version

--- a/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
+++ b/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
@@ -7,8 +7,8 @@ VERSION = os.getenv('VERSION')
 
 @flow
 def create_ingestion_workflow_versioning(transformer=None, mapper=None,
-                                         fetcher=None, importer=None,
-                                         updater=None
+                                         fetcher=None, minter=None,
+                                         importer=None, updater=None
                                          ):
     version_dict = {'workflow_orchestrator': VERSION}
 
@@ -52,6 +52,20 @@ def create_ingestion_workflow_versioning(transformer=None, mapper=None,
                      'dataverse-metadata-fetcher'
         )
         version_dict[fetcher_name] = fetcher
+
+    if minter:
+        minter_name = 'datacite-minter'
+        minter = get_service_version(
+            service_url='https://dataciteminter.labs.dans.knaw.nl/',
+            service_name=minter_name,
+            github_username='',
+            github_repo='',
+            docker_username='ekoindarto',
+            image_repo='submitmd2dc-service',
+            endpoint='https://dataciteminter.labs.dans.knaw.nl/'
+                     'submit-to-datacite/register'
+        )
+        version_dict[minter_name] = minter
 
     if importer:
         importer_name = 'dataverse-importer'

--- a/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
+++ b/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
@@ -10,6 +10,16 @@ def create_ingestion_workflow_versioning(transformer=None, mapper=None,
                                          fetcher=None, minter=None,
                                          importer=None, updater=None
                                          ):
+    """ Creates a version dictionary detailing a specific ingestion workflow.
+
+    The different workflows all use a set of services that have their own
+    versioning information. This flow creates a dictionary with up to date
+    information on the services passed as parameters. All parameters are bools
+    indicating if the service in question was used.
+
+    :return: A dictionary with all versioning information for a workflow.
+    """
+
     version_dict = {'workflow_orchestrator': VERSION}
 
     if transformer:

--- a/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
+++ b/prefect_docker/scripts/flows/workflow_versioning/workflow_versioner.py
@@ -1,0 +1,84 @@
+import os
+from prefect import flow
+from tasks.versioning_tasks import get_service_version
+
+VERSION = os.getenv('VERSION')
+
+
+@flow
+def create_ingestion_workflow_versioning(transformer=None, mapper=None,
+                                         fetcher=None, importer=None,
+                                         updater=None
+                                         ):
+    version_dict = {'workflow_orchestrator': VERSION}
+
+    if transformer:
+        transformer_name = 'DANS-transformer-service'
+        transformer = get_service_version(
+            service_url='https://transformer.labs.dans.knaw.nl/',
+            service_name=transformer_name,
+            github_username='',
+            github_repo='',
+            docker_username='ekoindarto',
+            image_repo='dans-transformer-service',
+            endpoint='https://transformer.labs.dans.knaw.nl/'
+                     'transform-xml-to-json/true'
+        )
+        version_dict[transformer_name] = transformer
+
+    if mapper:
+        mapper_name = 'dataverse-mapper'
+        mapper = get_service_version(
+            service_url='https://dataverse-mapper.labs.dans.knaw.nl/version',
+            service_name=mapper_name,
+            github_username='odissei-data',
+            github_repo=mapper_name,
+            docker_username='fjodorvr',
+            image_repo=mapper_name,
+            endpoint='https://dataverse-mapper.labs.dans.knaw.nl/mapper'
+        )
+        version_dict[mapper_name] = mapper
+
+    if fetcher:
+        fetcher_name = 'dataverse-metadata-fetcher'
+        fetcher = get_service_version(
+            service_url='https://dataverse-fetcher.labs.dans.knaw.nl/version',
+            service_name=fetcher_name,
+            github_username='odissei-data',
+            github_repo=fetcher_name,
+            docker_username='fjodorvr',
+            image_repo=fetcher_name,
+            endpoint='https://dataverse-fetcher.labs.dans.knaw.nl/'
+                     'dataverse-metadata-fetcher'
+        )
+        version_dict[fetcher_name] = fetcher
+
+    if importer:
+        importer_name = 'dataverse-importer'
+        importer = get_service_version(
+            service_url='https://dataverse-importer.labs.dans.knaw.nl/version',
+            service_name=importer_name,
+            github_username='odissei-data',
+            github_repo=importer_name,
+            docker_username='fjodorvr',
+            image_repo=importer_name,
+            endpoint='https://dataverse-importer.labs.dans.knaw.nl/importer'
+        )
+        version_dict[importer_name] = importer
+
+    if updater:
+        updater_name = 'publication-date-updater'
+        updater = get_service_version(
+            service_url='https://dataverse-date-updater.labs.dans.knaw.nl/'
+                        'version',
+            service_name=updater_name,
+            github_username='odissei-data',
+            github_repo=updater_name,
+            docker_username='fjodorvr',
+            image_repo=updater_name,
+            endpoint='https://dataverse-date-updater.labs.dans.knaw.nl/'
+                     'publication-date-updater'
+        )
+        version_dict[updater_name] = updater
+
+    return version_dict

--- a/prefect_docker/scripts/main_cbs_ingestion.py
+++ b/prefect_docker/scripts/main_cbs_ingestion.py
@@ -12,10 +12,13 @@ CBS_METADATA_DIRECTORY = os.getenv('CBS_METADATA_DIRECTORY')
 @flow
 def cbs_ingestion_pipeline():
     logger = get_run_logger()
-    logger.info(
-        create_ingestion_workflow_versioning(transformer=True, mapper=True,
-                                             importer=True, updater=True))
-    utils.workflow_executor(cbs_metadata_ingestion, CBS_METADATA_DIRECTORY)
+    version = create_ingestion_workflow_versioning(transformer=True,
+                                                   mapper=True,
+                                                   importer=True,
+                                                   updater=True)
+    logger.info(version)
+    utils.workflow_executor(cbs_metadata_ingestion, CBS_METADATA_DIRECTORY,
+                            version)
 
 
 if __name__ == "__main__":

--- a/prefect_docker/scripts/main_cbs_ingestion.py
+++ b/prefect_docker/scripts/main_cbs_ingestion.py
@@ -11,12 +11,11 @@ CBS_METADATA_DIRECTORY = os.getenv('CBS_METADATA_DIRECTORY')
 
 @flow
 def cbs_ingestion_pipeline():
-    logger = get_run_logger()
     version = create_ingestion_workflow_versioning(transformer=True,
                                                    mapper=True,
+                                                   minter=True,
                                                    importer=True,
                                                    updater=True)
-    logger.info(version)
     utils.workflow_executor(cbs_metadata_ingestion, CBS_METADATA_DIRECTORY,
                             version)
 

--- a/prefect_docker/scripts/main_cbs_ingestion.py
+++ b/prefect_docker/scripts/main_cbs_ingestion.py
@@ -1,13 +1,20 @@
 import os
+from prefect import flow, get_run_logger
+
 import utils
-from prefect import flow
 from flows.cbs_ingestion import cbs_metadata_ingestion
+from flows.workflow_versioning.workflow_versioner import \
+    create_ingestion_workflow_versioning
 
 CBS_METADATA_DIRECTORY = os.getenv('CBS_METADATA_DIRECTORY')
 
 
 @flow
 def cbs_ingestion_pipeline():
+    logger = get_run_logger()
+    logger.info(
+        create_ingestion_workflow_versioning(transformer=True, mapper=True,
+                                             importer=True, updater=True))
     utils.workflow_executor(cbs_metadata_ingestion, CBS_METADATA_DIRECTORY)
 
 

--- a/prefect_docker/scripts/main_dataverse_nl_ingestion.py
+++ b/prefect_docker/scripts/main_dataverse_nl_ingestion.py
@@ -2,14 +2,20 @@ import os
 import utils
 from prefect import flow
 from flows.dataverse_nl_ingestion import dataverse_nl_metadata_ingestion
+from flows.workflow_versioning.workflow_versioner import \
+    create_ingestion_workflow_versioning
 
 DATAVERSE_NL_METADATA_DIRECTORY = os.getenv('DATAVERSE_NL_METADATA_DIRECTORY')
 
 
 @flow
 def dataverse_nl_ingestion_pipeline():
+    version = create_ingestion_workflow_versioning(transformer=True,
+                                                   fetcher=True,
+                                                   importer=True,
+                                                   updater=True)
     utils.workflow_executor(dataverse_nl_metadata_ingestion,
-                            DATAVERSE_NL_METADATA_DIRECTORY)
+                            DATAVERSE_NL_METADATA_DIRECTORY, version)
 
 
 if __name__ == "__main__":

--- a/prefect_docker/scripts/main_easy_ingestion.py
+++ b/prefect_docker/scripts/main_easy_ingestion.py
@@ -2,13 +2,20 @@ import os
 import utils
 from prefect import flow
 from flows.easy_ingestion import easy_metadata_ingestion
+from flows.workflow_versioning.workflow_versioner import \
+    create_ingestion_workflow_versioning
 
 EASY_METADATA_DIRECTORY = os.getenv('EASY_METADATA_DIRECTORY')
 
 
 @flow
 def easy_ingestion_pipeline():
-    utils.workflow_executor(easy_metadata_ingestion, EASY_METADATA_DIRECTORY)
+    version = create_ingestion_workflow_versioning(transformer=True,
+                                                   mapper=True,
+                                                   importer=True,
+                                                   updater=True)
+    utils.workflow_executor(easy_metadata_ingestion, EASY_METADATA_DIRECTORY,
+                            version)
 
 
 if __name__ == "__main__":

--- a/prefect_docker/scripts/main_liss_ingestion.py
+++ b/prefect_docker/scripts/main_liss_ingestion.py
@@ -10,12 +10,10 @@ LISS_METADATA_DIRECTORY = os.getenv('LISS_METADATA_DIRECTORY')
 
 @flow
 def liss_ingestion_pipeline():
-    logger = get_run_logger()
     version = create_ingestion_workflow_versioning(transformer=True,
                                                    mapper=True,
                                                    importer=True,
                                                    updater=True)
-    logger.info(version)
     utils.workflow_executor(liss_metadata_ingestion, LISS_METADATA_DIRECTORY,
                             version)
 

--- a/prefect_docker/scripts/main_liss_ingestion.py
+++ b/prefect_docker/scripts/main_liss_ingestion.py
@@ -1,14 +1,23 @@
 import os
 import utils
-from prefect import flow
+from prefect import flow, get_run_logger
 from flows.liss_ingestion import liss_metadata_ingestion
+from flows.workflow_versioning.workflow_versioner import \
+    create_ingestion_workflow_versioning
 
 LISS_METADATA_DIRECTORY = os.getenv('LISS_METADATA_DIRECTORY')
 
 
 @flow
 def liss_ingestion_pipeline():
-    utils.workflow_executor(liss_metadata_ingestion, LISS_METADATA_DIRECTORY)
+    logger = get_run_logger()
+    version = create_ingestion_workflow_versioning(transformer=True,
+                                                   mapper=True,
+                                                   importer=True,
+                                                   updater=True)
+    logger.info(version)
+    utils.workflow_executor(liss_metadata_ingestion, LISS_METADATA_DIRECTORY,
+                            version)
 
 
 if __name__ == "__main__":

--- a/prefect_docker/scripts/tasks/base_tasks.py
+++ b/prefect_docker/scripts/tasks/base_tasks.py
@@ -300,6 +300,7 @@ def doi_minter(metadata):
 
 @task
 def add_workflow_versioning_url(mapped_metadata, version):
+    logger = get_run_logger()
     url = 'https://version-tracker.labs.dans.knaw.nl/store'
     headers = {
         'accept': 'application/json',
@@ -307,6 +308,9 @@ def add_workflow_versioning_url(mapped_metadata, version):
     }
 
     response = requests.post(url, headers=headers, data=json.dumps(version))
+    if not response.ok:
+        logger.info(response.json())
+        return None
 
     version_id = response.json()['id']
     version_field = 'https://version-tracker.labs.dans.knaw.nl/retrieve/' \

--- a/prefect_docker/scripts/tasks/base_tasks.py
+++ b/prefect_docker/scripts/tasks/base_tasks.py
@@ -300,7 +300,6 @@ def doi_minter(metadata):
 
 @task
 def add_workflow_versioning_url(mapped_metadata, version):
-    logger = get_run_logger()
     url = 'https://version-tracker.labs.dans.knaw.nl/store'
     headers = {
         'accept': 'application/json',
@@ -308,8 +307,6 @@ def add_workflow_versioning_url(mapped_metadata, version):
     }
 
     response = requests.post(url, headers=headers, data=json.dumps(version))
-    logger.info(response.json())
-    logger.info(response.text)
 
     version_id = response.json()['id']
     version_field = 'https://version-tracker.labs.dans.knaw.nl/retrieve/' \
@@ -338,5 +335,4 @@ def add_workflow_versioning_url(mapped_metadata, version):
             }
         }
     ]
-    logger.info(mapped_metadata)
     return mapped_metadata

--- a/prefect_docker/scripts/tasks/base_tasks.py
+++ b/prefect_docker/scripts/tasks/base_tasks.py
@@ -300,22 +300,14 @@ def doi_minter(metadata):
 
 @task
 def add_workflow_versioning_url(mapped_metadata, version):
-    logger = get_run_logger()
-    url = 'https://version-tracker.labs.dans.knaw.nl/store'
-    headers = {
-        'accept': 'application/json',
-        'Content-Type': 'application/json'
-    }
+    """ Adds the workflow versioning URL to the metadata.
 
-    response = requests.post(url, headers=headers, data=json.dumps(version))
-    if not response.ok:
-        logger.info(response.json())
-        return None
+    The workflow version that was created is saved
 
-    version_id = response.json()['id']
-    version_field = 'https://version-tracker.labs.dans.knaw.nl/retrieve/' \
-                    + version_id
-
+    :param mapped_metadata:
+    :param version:
+    :return:
+    """
     keys = ['datasetVersion', 'metadataBlocks', 'provenance']
     d = mapped_metadata
 
@@ -334,7 +326,7 @@ def add_workflow_versioning_url(mapped_metadata, version):
                     "typeName": "workflowURI",
                     "multiple": False,
                     "typeClass": "primitive",
-                    "value": version_field
+                    "value": version
                 },
             }
         }

--- a/prefect_docker/scripts/tasks/base_tasks.py
+++ b/prefect_docker/scripts/tasks/base_tasks.py
@@ -301,7 +301,7 @@ def doi_minter(metadata):
 @task
 def add_workflow_versioning_url(mapped_metadata, version):
     logger = get_run_logger()
-    url = 'http://host.docker.internal:8086/store'
+    url = 'https://version-tracker.labs.dans.knaw.nl/store'
     headers = {
         'accept': 'application/json',
         'Content-Type': 'application/json'
@@ -312,7 +312,8 @@ def add_workflow_versioning_url(mapped_metadata, version):
     logger.info(response.text)
 
     version_id = response.json()['id']
-    version_field = 'http://0.0.0.0:8086/retrieve/' + version_id
+    version_field = 'https://version-tracker.labs.dans.knaw.nl/retrieve/' \
+                    + version_id
 
     keys = ['datasetVersion', 'metadataBlocks', 'provenance']
     d = mapped_metadata

--- a/prefect_docker/scripts/tasks/base_tasks.py
+++ b/prefect_docker/scripts/tasks/base_tasks.py
@@ -302,11 +302,12 @@ def doi_minter(metadata):
 def add_workflow_versioning_url(mapped_metadata, version):
     """ Adds the workflow versioning URL to the metadata.
 
-    The workflow version that was created is saved
+    The workflow version URL that was created is added to the provenance
+    metadata block.
 
-    :param mapped_metadata:
-    :param version:
-    :return:
+    :param mapped_metadata: The Dataverse formatted metadata.
+    :param version: The version URL.
+    :return: The metadata containing the version URL in the provenance block.
     """
     keys = ['datasetVersion', 'metadataBlocks', 'provenance']
     d = mapped_metadata

--- a/prefect_docker/scripts/tasks/versioning_tasks.py
+++ b/prefect_docker/scripts/tasks/versioning_tasks.py
@@ -1,0 +1,66 @@
+import os
+import requests
+from prefect import task, get_run_logger
+
+GITHUB_USERNAME = os.getenv('GITHUB_USERNAME')
+DOCKERHUB_USERNAME = os.getenv('DOCKERHUB_USERNAME')
+
+
+@task
+def get_service_version(service_url, service_name, github_username,
+                        github_repo, docker_username, image_repo, endpoint):
+    service_version = {
+            'name': service_name,
+            'version': get_deployed_service_version(service_url),
+            'github-release': get_latest_github_release_version(
+                github_username, github_repo),
+            'docker-image': get_latest_image_tag_version(docker_username,
+                                                         image_repo),
+            'endpoint': endpoint,
+        }
+
+    return service_version
+
+
+def get_latest_image_tag_version(docker_username, image_repo):
+    logger = get_run_logger()
+
+    response = requests.get('https://registry.hub.docker.com/v2/repositories/'
+                            f'{docker_username}/{image_repo}/tags')
+
+    if not response.ok:
+        logger.info(response.json())
+        return None
+
+    tags = response.json()
+
+    latest_tag = max(tags['results'], key=lambda x: x['last_updated'])
+    latest_tag_link = 'https://hub.docker.com/r/' \
+                      f'{DOCKERHUB_USERNAME}/{image_repo}/tags/' \
+                      f'{latest_tag["name"]}'
+
+    return latest_tag_link
+
+
+def get_latest_github_release_version(github_username, github_repo):
+    logger = get_run_logger()
+
+    response = requests.get('https://api.github.com/repos/'
+                            f'{github_username}/{github_repo}/releases/latest')
+
+    if not response.ok:
+        logger.info(response.json())
+        return None
+
+    return response.json()['html_url']
+
+
+def get_deployed_service_version(service_url):
+    logger = get_run_logger()
+    response = requests.get(service_url)
+
+    if not response.ok:
+        logger.info(response.json())
+        return None
+
+    return response.json()['version']

--- a/prefect_docker/scripts/tasks/versioning_tasks.py
+++ b/prefect_docker/scripts/tasks/versioning_tasks.py
@@ -18,15 +18,19 @@ def get_service_version(service_url, service_name, github_username,
 
     :return: A version dictionary detailing the version of the service.
     """
+
     service_version = {
         'name': service_name,
         'version': get_deployed_service_version(service_url),
-        'github-release': get_latest_github_release_version(
-            github_username, github_repo),
         'docker-image': get_latest_image_tag_version(docker_username,
                                                      image_repo),
         'endpoint': endpoint,
     }
+
+    github_release = get_latest_github_release_version(
+        github_username, github_repo)
+    if github_release:
+        service_version['github-release'] = github_release
 
     return service_version
 

--- a/prefect_docker/scripts/tasks/versioning_tasks.py
+++ b/prefect_docker/scripts/tasks/versioning_tasks.py
@@ -36,7 +36,7 @@ def get_latest_image_tag_version(docker_username, image_repo):
 
     latest_tag = max(tags['results'], key=lambda x: x['last_updated'])
     latest_tag_link = 'https://hub.docker.com/r/' \
-                      f'{DOCKERHUB_USERNAME}/{image_repo}/tags/' \
+                      f'{docker_username}/{image_repo}/tags/' \
                       f'{latest_tag["name"]}'
 
     return latest_tag_link

--- a/prefect_docker/scripts/tasks/versioning_tasks.py
+++ b/prefect_docker/scripts/tasks/versioning_tasks.py
@@ -10,6 +10,14 @@ DOCKERHUB_USERNAME = os.getenv('DOCKERHUB_USERNAME')
 @task
 def get_service_version(service_url, service_name, github_username,
                         github_repo, docker_username, image_repo, endpoint):
+    """ Creates a version dictionary for a specific service.
+
+    This function creates a dictionary for a specific service.
+    It expects the necessary information to retrieve the service version,
+    GitHub repository, and Dockerhub repository.
+
+    :return: A version dictionary detailing the version of the service.
+    """
     service_version = {
         'name': service_name,
         'version': get_deployed_service_version(service_url),
@@ -24,6 +32,15 @@ def get_service_version(service_url, service_name, github_username,
 
 
 def get_latest_image_tag_version(docker_username, image_repo):
+    """ Grabs the latest tag version of the given image.
+
+    Searches through the list of fetched tags from the docker hub.
+    Grabs the most recent tag that was added to the list.
+
+    :param docker_username: The user who owns the repo.
+    :param image_repo: The name of the image repo.
+    :return: A URL that contains the latest image tag.
+    """
     logger = get_run_logger()
 
     response = requests.get('https://registry.hub.docker.com/v2/repositories/'
@@ -44,6 +61,14 @@ def get_latest_image_tag_version(docker_username, image_repo):
 
 
 def get_latest_github_release_version(github_username, github_repo):
+    """ Grabs the latest GitHub release of the given GitHub repo.
+
+    This task uses the GitHub API to fetch the latest release of a repo.
+
+    :param github_username: The username of the owner of the repo.
+    :param github_repo: The name of the GitHub repository.
+    :return: URL that links to the latest release page of the repository.
+    """
     logger = get_run_logger()
 
     response = requests.get('https://api.github.com/repos/'
@@ -57,6 +82,13 @@ def get_latest_github_release_version(github_username, github_repo):
 
 
 def get_deployed_service_version(service_url):
+    """ Returns the service version.
+
+    Uses the version endpoint of the service to fetch the current version.
+
+    :param service_url: The endpoint of the service that returns the version.
+    :return: The service version.
+    """
     logger = get_run_logger()
     response = requests.get(service_url)
 
@@ -68,6 +100,16 @@ def get_deployed_service_version(service_url):
 
 
 def store_workflow_version(version_dict):
+    """ Stores the workflow version dictionary.
+
+    The workflow version dictionary is stored using the version-tracker.
+    A POST request is made to store the dict, which then response with an ID.
+    This ID is used to formulate a GET request that can be used to fetch
+    the dictionary.
+
+    :param version_dict: The complete version dictionary of the workflow.
+    :return: A GET request.
+    """
     logger = get_run_logger()
     url = 'https://version-tracker.labs.dans.knaw.nl/store'
     headers = {

--- a/prefect_docker/scripts/utils.py
+++ b/prefect_docker/scripts/utils.py
@@ -44,12 +44,14 @@ def is_lower_level_liss_study(metadata):
         return True, title
 
 
-def workflow_executor(data_provider_workflow, metadata_directory):
+def workflow_executor(data_provider_workflow, metadata_directory,
+                      version=None):
     """ Executes the workflow of a give data provider for each metadata file.
 
     Takes workflow flow that ingests a single metadata file of a data provider
     and executes that workflow for every metadata file in the given directory.
 
+    :param version: A dictionary containing all version info of the workflow.
     :param data_provider_workflow: The workflow to ingest the metadata file.
     :param metadata_directory: The directory where provider's metadata lives.
     """
@@ -58,4 +60,4 @@ def workflow_executor(data_provider_workflow, metadata_directory):
     for filename in files:
         file_path = os.path.join(metadata_directory, filename)
         if os.path.isfile(file_path):
-            data_provider_workflow(file_path, return_state=True)
+            data_provider_workflow(file_path, version, return_state=True)

--- a/prefect_docker/scripts/utils.py
+++ b/prefect_docker/scripts/utils.py
@@ -45,7 +45,7 @@ def is_lower_level_liss_study(metadata):
 
 
 def workflow_executor(data_provider_workflow, metadata_directory,
-                      version=None):
+                      version):
     """ Executes the workflow of a give data provider for each metadata file.
 
     Takes workflow flow that ingests a single metadata file of a data provider


### PR DESCRIPTION
## Workflow versioning
### Work done
Added functionality that creates a workflow version using a flow. This flow fetches the latest GitHub Repo release, the latest image tag and the version of every service that is indicated a given ingestion workflow uses. It creates a dictionary with all the services and the prefect version information bundled together. This dictionary is stored in the version-tracker service and an ID is returned that can be used with a GET request to retrieve it. 

An extra task was made to add the workflow version GET URL to the provenance metadata block. This task was added to all ingestion workflows.