### PR TITLE
ODSP-147 Semantic enrichment task

### DIFF
--- a/prefect_docker/scripts/configuration/settings.toml
+++ b/prefect_docker/scripts/configuration/settings.toml
@@ -1,4 +1,5 @@
 [default]
+ELSST_SKOSMOS_URL="https://thesauri.cessda.eu"
 
 [development]
 debug = true
@@ -12,8 +13,7 @@ DATAVERSE_MAPPER_URL="http://dataverse-mapper-v2:8094"
 DANS_TRANSFORMER_SERVICE="https://transformer.labs.dans.knaw.nl"
 EMAIL_SANITATION_SERVICE="https://emailsanitizer.labs.dans.knaw.nl/sanitize"
 METADATA_REFINER_URL="http://metadata-refiner:7878"
-
-BUCKET_NAME = "harvested-metadata"
+SEMANTIC_API_URL= "http://semanticapi:80/importdoi"
 
 [production]
 debug = false
@@ -26,5 +26,4 @@ DATAVERSE_MAPPER_URL="https://dataverse-mapper.labs.dans.knaw.nl"
 DANS_TRANSFORMER_SERVICE="https://transformer.labs.dans.knaw.nl"
 EMAIL_SANITIZER_URL="https://emailsanitizer.labs.dans.knaw.nl/sanitize"
 METADATA_REFINER_URL="https://metadata-refiner.labs.dans.knaw.nl"
-
-BUCKET_NAME = "harvested-metadata"
+SEMANTIC_API_URL="https://semantic-enrichment.labs.dans.knaw.nl"

--- a/prefect_docker/scripts/flows/dataset_workflows/cbs_ingestion.py
+++ b/prefect_docker/scripts/flows/dataset_workflows/cbs_ingestion.py
@@ -5,7 +5,7 @@ from prefect.orion.schemas.states import Completed, Failed
 from queries import CBS_ID_QUERY, DIST_DATE_QUERY
 from tasks.base_tasks import xml2json, dataverse_mapper, \
     dataverse_import, update_publication_date, add_workflow_versioning_url, \
-    sanitize_emails
+    sanitize_emails, semantic_enrichment
 
 
 @flow
@@ -55,5 +55,9 @@ def cbs_metadata_ingestion(xml_metadata, version, settings_dict):
         )
         if not pub_date_response:
             return Failed(message='Unable to update publication date.')
+
+    enrichment_response = semantic_enrichment(settings_dict, doi)
+    if not enrichment_response:
+        return Failed(message="Unable to add enrichments.")
 
     return Completed(message=doi + 'ingested successfully.')

--- a/prefect_docker/scripts/tasks/base_tasks.py
+++ b/prefect_docker/scripts/tasks/base_tasks.py
@@ -132,7 +132,7 @@ def update_publication_date(publication_date, pid, settings_dict):
 
     :param publication_date: The original date of publication.
     :param pid: The DOI of the dataset in question.
-    :param settings_dict: dict, contains settings for the current task
+    :param settings_dict: dict, contains settings for the current task.
     :return: Response body on success | None on failure.
     """
     logger = get_run_logger()
@@ -389,6 +389,7 @@ def semantic_enrichment(settings_dict, pid: str):
     It then matches those keywords on ELSST terms and adds them to the search
     index of SOLR. This makes them searchable in Dataverse.
 
+    :param settings_dict: Contains settings for the current task.
     :param pid: The pid of the dataset.
     """
     logger = get_run_logger()


### PR DESCRIPTION
## Semantic enrichment
### Description
CBS metadata now has a task that enriches the SOLR search index. The task uses the semantic enrichment API sending the pid of the dataset to enrich. The service then matches keywords in the metadata with ELSST translations and adds them to search index.
### Work done
- Created task that calls the semantic enrichment API.
- Added task to the CBS workflow.
- Add urls needed for the API to config.