### PR TITLE
ODSP-321: full harvest as optional param

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Fixes Jira issue ODSP-
+
+# Description of changes
+
+# How to test
+
+# Related PRs
+
+(Add links)
+
+*
+
+# Notify

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TARGET_URL ?=
 TARGET_KEY ?=
 TARGET_BUCKET ?=
 DO_HARVEST ?= True
+FULL_HARVEST ?= False
 
 .PHONY = help
 .DEFAULT:
@@ -62,6 +63,6 @@ submodules: ## Sets up the submodules and checks out their main branch.
 	git submodule foreach git checkout main
 	git submodule foreach git pull origin main
 ingest: ## Runs the ingest workflow for a specified data provider. The url and key of the target can be optionally added. eg: make ingest data_provider=CBS TARGET_URL=https://portal.example.odissei.nl TARGET_KEY=abcde123-11aa-22bb-3c4d-098765432abc
-	@docker exec -it ${PROJECT_CONTAINER_NAME} python run_ingestion.py --data_provider=$(data_provider) --target_url=$(TARGET_URL) --target_key=$(TARGET_KEY) --target_bucket=$(TARGET_BUCKET) --do_harvest=$(DO_HARVEST)
+	@docker exec -it ${PROJECT_CONTAINER_NAME} python run_ingestion.py --data_provider=$(data_provider) --target_url=$(TARGET_URL) --target_key=$(TARGET_KEY) --target_bucket=$(TARGET_BUCKET) --do_harvest=$(DO_HARVEST) --full_harvest=$(FULL_HARVEST)
 deploy: ## Deploys all ingestion workflows to the prefect server.
 	@docker exec -it prefect python deployment/deploy_ingestion_pipelines.py

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,8 @@ specific target Dataverse. If you do not provide them, it will use the target
 in the settings in `odissei_settings.toml` and the key in `.secrets.toml`. It also
 allows you to specify if the pipeline should first harvest the metadata.
 This is useful for quick dev'ing after the metadata was already harvested or
-to rerun the bucket with metadata files from failed dataset workflows.
+to rerun the bucket with metadata files from failed dataset workflows. 
+Forcing a re-harvesting of all datasets can be accomplished using the `FULL_HARVEST=True` option. 
 There is also an option to override the default bucket name by specifying the target bucket. 
 
 This is the list of data providers that can be used in the `make ingest` command:

--- a/scripts/flows/entry_workflows/main_cbs_ingestion.py
+++ b/scripts/flows/entry_workflows/main_cbs_ingestion.py
@@ -11,9 +11,13 @@ from flows.workflow_versioning.workflow_versioner import \
 def cbs_ingestion_pipeline(target_url: str = "", 
                            target_key: str = "",
                            target_bucket: str = "",
-                           do_harvest: bool=False):
+                           do_harvest: bool=False,
+                           full_harvest: bool=False
+                           ):
     """ Ingestion pipeline dedicated to the CBS metadata ingestion.
 
+    :param full_harvest: Boolean stating if a full harvest should be performed. 
+     Not used for CBS yet.
     :param do_harvest: Boolean stating if the dataset metadata should be
      harvested before ingestion. Not used for CBS yet.
     :param target_bucket: Optional target S3 bucket name.

--- a/scripts/flows/entry_workflows/main_cid_ingestion.py
+++ b/scripts/flows/entry_workflows/main_cid_ingestion.py
@@ -13,9 +13,12 @@ from tasks.harvest_tasks import oai_harvest_metadata, \
 def cid_ingestion_pipeline(target_url: str = "", 
                            target_key: str = "",
                            target_bucket: str = "",
-                           do_harvest: bool = True):
+                           do_harvest: bool = True,
+                           full_harvest: bool = False
+                           ):
     """ Ingestion pipeline dedicated to the CID metadata ingestion.
 
+    :param full_harvest: Boolean stating if a full harvest should be performed.
     :param do_harvest: Boolean stating if the dataset metadata should be
      harvested before ingestion.
     :param target_bucket: Optional target S3 bucket name.
@@ -45,7 +48,10 @@ def cid_ingestion_pipeline(target_url: str = "",
     minio_client = utils.create_s3_client()
 
     if do_harvest:
-        timestamp = get_most_recent_publication_date(settings_dict)
+        if full_harvest:
+            timestamp = None
+        else:
+            timestamp = get_most_recent_publication_date(settings_dict)
 
         harvest_params = {
             'metadata_prefix': settings.CID_METADATA_PREFIX,

--- a/scripts/flows/entry_workflows/main_dataverse_ingestion.py
+++ b/scripts/flows/entry_workflows/main_dataverse_ingestion.py
@@ -15,10 +15,12 @@ def dataverse_ingestion_pipeline(settings_dict_name: str,
                                  target_url: str = "",
                                  target_key: str = "",
                                  target_bucket: str = "",
-                                 do_harvest: bool = True
+                                 do_harvest: bool = True,
+                                 full_harvest: bool = False
                                  ):
     """ Ingestion pipeline dedicated to the Dataverse to Dataverse workflow.
 
+    :param full_harvest: Boolean stating if a full harvest should be performed.
     :param do_harvest: Boolean stating if the dataset metadata should be
      harvested before ingestion.
     :param target_bucket: Optional target S3 bucket name.
@@ -49,7 +51,10 @@ def dataverse_ingestion_pipeline(settings_dict_name: str,
     minio_client = utils.create_s3_client()
 
     if do_harvest:
-        timestamp = get_most_recent_publication_date(settings_dict)
+        if full_harvest:
+            timestamp = None
+        else:
+            timestamp = get_most_recent_publication_date(settings_dict)
 
         harvest_params = {
             'metadata_prefix': settings.METADATA_PREFIX,

--- a/scripts/flows/entry_workflows/main_liss_ingestion.py
+++ b/scripts/flows/entry_workflows/main_liss_ingestion.py
@@ -13,9 +13,11 @@ from tasks.harvest_tasks import harvest_metadata, \
 def liss_ingestion_pipeline(target_url: str = "", 
                             target_key: str = "",
                             target_bucket: str = "",
-                            do_harvest: bool = True):
+                            do_harvest: bool = True,
+                            full_harvest: bool = False
+                            ):
     """ Ingestion pipeline dedicated to the LISS metadata ingestion.
-
+    :param full_harvest: Boolean stating if a full harvest should be performed.
     :param do_harvest: Boolean stating if the dataset metadata should be
      harvested before ingestion.
     :param target_bucket: Optional target S3 bucket name.
@@ -43,7 +45,11 @@ def liss_ingestion_pipeline(target_url: str = "",
     s3_client = utils.create_s3_client()
 
     if do_harvest:
-        timestamp = get_most_recent_publication_date(settings_dict)
+        if full_harvest:
+            timestamp = None
+        else:
+            timestamp = get_most_recent_publication_date(settings_dict)
+
         harvest_metadata(
             settings_dict.BUCKET_NAME,
             "start_liss_harvest",

--- a/scripts/run_ingestion.py
+++ b/scripts/run_ingestion.py
@@ -69,20 +69,19 @@ def run_ingestion():
         settings_dict["from"] = args.harvest_from
 
     if args.target_bucket:
-        settings_dict.BUCKET_NAME = args.target_bucket
-    # Note that the target bucket is not passed as parameter, as the
-    # dataverse_ingestion_pipeline function retrieves it from the
-    # settings_dict
+        target_bucket = args.target_bucket
+    else:
+        target_bucket = ""
 
     if args.data_provider in provider_mapping:
         ingestion_function = provider_mapping[args.data_provider]
         target_url = get_target_url(args.target_url, settings_dict)
-        ingestion_function(target_url, args.target_key, "", do_harvest, full_harvest)
+        ingestion_function(target_url, args.target_key, target_bucket, do_harvest, full_harvest)
 
     else:
         target_url = get_target_url(args.target_url, settings_dict)
         dataverse_ingestion_pipeline(args.data_provider, target_url,
-                                     args.target_key, "", do_harvest, full_harvest)
+                                     args.target_key, target_bucket, do_harvest, full_harvest)
 
 
 def get_target_url(target_url, settings_dict):

--- a/scripts/run_ingestion.py
+++ b/scripts/run_ingestion.py
@@ -47,7 +47,9 @@ def run_ingestion():
     print(f"args: {args}")
     do_harvest = args.do_harvest.lower() == 'true'
     full_harvest = args.full_harvest.lower() == 'true' 
-
+    if full_harvest and do_harvest is False:
+        print("WARNING: Note that full_harvest is ignored because do_harvest is False!")
+    
     provider_mapping = {
         'CBS': cbs_ingestion_pipeline,
         'LISS': liss_ingestion_pipeline,
@@ -55,13 +57,13 @@ def run_ingestion():
     }
 
     if args.data_provider not in data_providers:
-        print(f"Invalid data provider specified, please choose from this list:"
+        print(f"ERROR: Invalid data provider specified, please choose from this list:"
               f" {data_providers}")
         return
 
     if args.harvest_from and not validate_datestamp(args.harvest_from):
         print(
-            f"Invalid datestamp specified, please use the format YYYY-MM-DD.")
+            f"ERROR: Invalid datestamp specified, please use the format YYYY-MM-DD.")
         return
 
     settings_dict = getattr(settings, args.data_provider)

--- a/scripts/run_ingestion.py
+++ b/scripts/run_ingestion.py
@@ -39,10 +39,15 @@ def run_ingestion():
     parser.add_argument('--harvest_from', type=str, default=None,
                         help='Datestamps used as values of the optional '
                              'argument from will be harvested.')
+    parser.add_argument('--full_harvest', type=str, default="False",
+                        help='Bool that states if a full harvest should be'
+                             ' performed.')
     args = parser.parse_args()
 
     print(f"args: {args}")
     do_harvest = args.do_harvest.lower() == 'true'
+    full_harvest = args.full_harvest.lower() == 'true' 
+
     provider_mapping = {
         'CBS': cbs_ingestion_pipeline,
         'LISS': liss_ingestion_pipeline,
@@ -72,12 +77,12 @@ def run_ingestion():
     if args.data_provider in provider_mapping:
         ingestion_function = provider_mapping[args.data_provider]
         target_url = get_target_url(args.target_url, settings_dict)
-        ingestion_function(target_url, args.target_key, "", do_harvest)
+        ingestion_function(target_url, args.target_key, "", do_harvest, full_harvest)
 
     else:
         target_url = get_target_url(args.target_url, settings_dict)
         dataverse_ingestion_pipeline(args.data_provider, target_url,
-                                     args.target_key, "", do_harvest)
+                                     args.target_key, "", do_harvest, full_harvest)
 
 
 def get_target_url(target_url, settings_dict):


### PR DESCRIPTION
Fixes Jira issue ODSP-321

# Description of changes

Full harvest means that we disregard the timestamp of the latest dataset of the provider in the destination (portal). So, instead of only harvesting newer (published) datasets we do them all. 

# How to test

First do an ingest with harvest, but not full. If the datasets where not in the target portal, then all will be ingested. 
When doing this the seccond time, only that latest dataset will be ingested. 
Finaly using that full_harvest will show that all datasets are ingested again. 

Note that the AVANS was not a good example here because the OAI timestamps made harvesting all datasets anyway, use LEIDEN instead. 

Also check that after a `make deploy` the Deployements 'Custom run' dialog does show the new option. 

# Related PRs

(Add links)

*

# Notify